### PR TITLE
Fix/cosign installer v4

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -32,10 +32,10 @@ jobs:
         run: |
           # The shell will safely write the multiline env var to a file
           echo "$COSIGN_KEY_DATA" > temp.key
-          
+
           # 2. Test actual signing
           echo "test-data" > test.txt
-          cosign sign-blob --key temp.key --bundle test.bundle test.txt
+          cosign sign-blob --key temp.key --bundle test.bundle --yes=true test.txt
         env:
           COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
           COSIGN_KEY_DATA: ${{ secrets.COSIGN_KEY }}

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.1.1
+        uses: sigstore/cosign-installer@v4.0.0  # v4 installs cosign v3.x (v3.x installs cosign v2.x)
 
       - name: Test key derivation
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .cosign-password.txt
 cosign.key
+cosign.key.base64
+test.bundle
+test.txt
+test.txt.cosign.bundle

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+echo "test" > test.txt
+
+cosign sign-blob --key cosign.key ./test.txt --output-signature ./test.sig --bundle ./test.txt.cosign.bundle
+
+cosign verify-blob --key ./cosign.pub --bundle ./test.txt.cosign.bundle  test.txt
+
+gh secret set COSIGN_KEY --org innago-property-management --visibility all < cosign.key
+base64 <<< cosign.key > cosign.key.base64 
+gh secret set COSIGN_KEY_ENCODED --org innago-property-management --visibility all < cosign.key.base64
+gh secret set COSIGN_PASSWORD --org innago-property-management --visibility all < .cosign-password.txt
+


### PR DESCRIPTION
## Summary by Sourcery

Update Cosign usage to be compatible with the latest installer and add a helper script for local Cosign signing and secret setup.

CI:
- Bump Cosign GitHub Action installer to v4.0.0 and adjust the signing command to work non-interactively in the verification workflow.

Chores:
- Add a setup script to generate a test artifact, sign and verify it with Cosign, and populate GitHub organization secrets for Cosign keys and password.